### PR TITLE
BitBucket SDK APIs

### DIFF
--- a/bitbucket/internal/repository_impl.go
+++ b/bitbucket/internal/repository_impl.go
@@ -1,0 +1,205 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
+	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/v2/service"
+	"github.com/ctreminiom/go-atlassian/v2/service/bitbucket"
+)
+
+// NewRepositoryService creates a new instance of the repository service
+func NewRepositoryService(client service.Connector) *RepositoryService {
+	return &RepositoryService{
+		internalClient: &internalRepositoryServiceImpl{c: client},
+	}
+}
+
+// RepositoryService handles communication with the repository related methods
+type RepositoryService struct {
+	internalClient bitbucket.RepositoryConnector
+}
+
+// List returns a paginated list of all repositories owned by the specified workspace
+//
+// GET /2.0/repositories/{workspace}
+//
+// https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-get
+func (r *RepositoryService) List(ctx context.Context, workspace string) (*model.RepositoryPageScheme, *model.ResponseScheme, error) {
+	return r.internalClient.List(ctx, workspace)
+}
+
+type internalRepositoryServiceImpl struct {
+	c service.Connector
+}
+
+// List returns a paginated list of all repositories owned by the specified workspace
+func (i *internalRepositoryServiceImpl) List(ctx context.Context, workspace string) (*model.RepositoryPageScheme, *model.ResponseScheme, error) {
+	if workspace == "" {
+		return nil, nil, model.ErrNoWorkspace
+	}
+
+	endpoint := fmt.Sprintf("2.0/repositories/%v", workspace)
+
+	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	page := new(model.RepositoryPageScheme)
+	response, err := i.c.Call(request, page)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return page, response, nil
+}
+
+// Create creates a new repository in the specified workspace
+//
+// POST /2.0/repositories/{workspace}/{repo_slug}
+func (i *internalRepositoryServiceImpl) Create(ctx context.Context, workspace string, repository string, payload *model.RepositoryScheme) (*model.RepositoryScheme, *model.ResponseScheme, error) {
+	if workspace == "" {
+		return nil, nil, model.ErrNoWorkspace
+	}
+
+	if repository == "" {
+		return nil, nil, model.ErrNoRepository
+	}
+
+	endpoint := fmt.Sprintf("2.0/repositories/%v/%v", workspace, repository)
+
+	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	repo := new(model.RepositoryScheme)
+	response, err := i.c.Call(request, repo)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return repo, response, nil
+}
+
+// Also add the method to the RepositoryService
+func (r *RepositoryService) Create(ctx context.Context, workspace string, repository string, payload *model.RepositoryScheme) (*model.RepositoryScheme, *model.ResponseScheme, error) {
+	return r.internalClient.Create(ctx, workspace, repository, payload)
+}
+
+// ListBranchRestrictions returns a paginated list of all branch restrictions on the repository
+//
+// GET /2.0/repositories/{workspace}/{repo_slug}/branch-restrictions
+//
+// https://developer.atlassian.com/cloud/bitbucket/rest/api-group-branch-restrictions/#api-repositories-workspace-repo-slug-branch-restrictions-get
+func (r *RepositoryService) ListBranchRestrictions(ctx context.Context, workspace, repoSlug string) (*model.BranchRestrictionsPageScheme, *model.ResponseScheme, error) {
+	return r.internalClient.ListBranchRestrictions(ctx, workspace, repoSlug)
+}
+
+func (i *internalRepositoryServiceImpl) ListBranchRestrictions(ctx context.Context, workspace, repoSlug string) (*model.BranchRestrictionsPageScheme, *model.ResponseScheme, error) {
+	if workspace == "" {
+		return nil, nil, model.ErrNoWorkspace
+	}
+
+	if repoSlug == "" {
+		return nil, nil, model.ErrNoRepository
+	}
+
+	endpoint := fmt.Sprintf("2.0/repositories/%v/%v/branch-restrictions", workspace, repoSlug)
+
+	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	branchRestrictions := new(model.BranchRestrictionsPageScheme)
+	response, err := i.c.Call(request, branchRestrictions)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return branchRestrictions, response, nil
+}
+
+// ListDefaultReviewers returns a paginated list of default reviewers for the repository
+//
+// GET /2.0/repositories/{workspace}/{repo_slug}/default-reviewers
+//
+// https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-default-reviewers-get
+func (r *RepositoryService) ListDefaultReviewers(ctx context.Context, workspace, repoSlug string) (*model.DefaultReviewersPageScheme, *model.ResponseScheme, error) {
+	return r.internalClient.ListDefaultReviewers(ctx, workspace, repoSlug)
+}
+
+func (i *internalRepositoryServiceImpl) ListDefaultReviewers(ctx context.Context, workspace, repoSlug string) (*model.DefaultReviewersPageScheme, *model.ResponseScheme, error) {
+	if workspace == "" {
+		return nil, nil, model.ErrNoWorkspace
+	}
+
+	if repoSlug == "" {
+		return nil, nil, model.ErrNoRepository
+	}
+
+	endpoint := fmt.Sprintf("2.0/repositories/%v/%v/default-reviewers", workspace, repoSlug)
+
+	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defaultReviewers := new(model.DefaultReviewersPageScheme)
+	response, err := i.c.Call(request, defaultReviewers)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return defaultReviewers, response, nil
+}
+
+// ListPullRequests returns all pull requests on the specified repository
+//
+// GET /2.0/repositories/{workspace}/{repo_slug}/pullrequests
+//
+// https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-get
+func (r *RepositoryService) ListPullRequests(ctx context.Context, workspace, repoSlug string) (*models.PullRequestsResponse, *models.ResponseScheme, error) {
+	return r.internalClient.ListPullRequests(ctx, workspace, repoSlug)
+}
+
+func (i *internalRepositoryServiceImpl) ListPullRequests(ctx context.Context, workspace, repoSlug string) (*models.PullRequestsResponse, *models.ResponseScheme, error) {
+	if workspace == "" {
+		return nil, nil, models.ErrNoWorkspace
+	}
+
+	if repoSlug == "" {
+		return nil, nil, models.ErrNoRepository
+	}
+
+	endpoint := fmt.Sprintf("2.0/repositories/%v/%v/pullrequests", workspace, repoSlug)
+
+	// Add all states to query parameters
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	q := url.Values{}
+	q.Add("state", "OPEN,MERGED,DECLINED,SUPERSEDED")
+	u.RawQuery = q.Encode()
+
+	request, err := i.c.NewRequest(ctx, http.MethodGet, u.String(), "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pullRequests := new(models.PullRequestsResponse)
+	response, err := i.c.Call(request, pullRequests)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return pullRequests, response, nil
+}

--- a/bitbucket/internal/repository_impl_test.go
+++ b/bitbucket/internal/repository_impl_test.go
@@ -1,0 +1,564 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepositoryService_List(t *testing.T) {
+
+	type args struct {
+		ctx       context.Context
+		workspace string
+	}
+
+	testCases := []struct {
+		name    string
+		args    args
+		on      func(*testing.T) (*RepositoryService, *models.ResponseScheme)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the workspace is not provided",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(nil)
+				return client, nil
+			},
+			wantErr: true,
+			Err:     models.ErrNoWorkspace,
+		},
+		{
+			name: "when the http request cannot be created",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						return nil, nil
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						return nil, fmt.Errorf("error creating request")
+					},
+				})
+				return client, nil
+			},
+			wantErr: true,
+			Err:     fmt.Errorf("error creating request"),
+		},
+		{
+			name: "when the http request fails",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						return nil, fmt.Errorf("error making request")
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						return &http.Request{}, nil
+					},
+				})
+				return client, nil
+			},
+			wantErr: true,
+			Err:     fmt.Errorf("error making request"),
+		},
+		{
+			name: "when the request is successful",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						resp := &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       nil,
+						}
+						return resp, nil
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						assert.Equal(t, "GET", method)
+						assert.Equal(t, "2.0/repositories/workspace-uuid", path)
+						return &http.Request{}, nil
+					},
+				})
+
+				return client, &models.ResponseScheme{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+					},
+				}
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, _ := testCase.on(t)
+
+			gotResult, gotResponse, err := client.List(testCase.args.ctx, testCase.args.workspace)
+
+			if testCase.wantErr {
+				assert.Error(t, err)
+				assert.EqualError(t, err, testCase.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func TestRepositoryService_ListBranchRestrictions(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		workspace string
+		repoSlug  string
+	}
+
+	testCases := []struct {
+		name    string
+		args    args
+		on      func(*testing.T) (*RepositoryService, *models.ResponseScheme)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the workspace is not provided",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(nil)
+				return client, nil
+			},
+			wantErr: true,
+			Err:     models.ErrNoWorkspace,
+		},
+		{
+			name: "when the repository slug is not provided",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(nil)
+				return client, nil
+			},
+			wantErr: true,
+			Err:     models.ErrNoRepository,
+		},
+		{
+			name: "when the http request cannot be created",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						return nil, nil
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						return nil, fmt.Errorf("error creating request")
+					},
+				})
+				return client, nil
+			},
+			wantErr: true,
+			Err:     fmt.Errorf("error creating request"),
+		},
+		{
+			name: "when the http request fails",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						return nil, fmt.Errorf("error making request")
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						return &http.Request{}, nil
+					},
+				})
+				return client, nil
+			},
+			wantErr: true,
+			Err:     fmt.Errorf("error making request"),
+		},
+		{
+			name: "when the request is successful",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						resp := &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       nil,
+						}
+						return resp, nil
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						assert.Equal(t, "GET", method)
+						assert.Equal(t, "2.0/repositories/workspace-uuid/repo-slug/branch-restrictions", path)
+						return &http.Request{}, nil
+					},
+				})
+
+				return client, &models.ResponseScheme{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+					},
+				}
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, _ := testCase.on(t)
+
+			gotResult, gotResponse, err := client.ListBranchRestrictions(testCase.args.ctx, testCase.args.workspace, testCase.args.repoSlug)
+
+			if testCase.wantErr {
+				assert.Error(t, err)
+				assert.EqualError(t, err, testCase.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func TestRepositoryService_ListDefaultReviewers(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		workspace string
+		repoSlug  string
+	}
+
+	testCases := []struct {
+		name    string
+		args    args
+		on      func(*testing.T) (*RepositoryService, *models.ResponseScheme)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the workspace is not provided",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(nil)
+				return client, nil
+			},
+			wantErr: true,
+			Err:     models.ErrNoWorkspace,
+		},
+		{
+			name: "when the repository slug is not provided",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(nil)
+				return client, nil
+			},
+			wantErr: true,
+			Err:     models.ErrNoRepository,
+		},
+		{
+			name: "when the http request cannot be created",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						return nil, nil
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						return nil, fmt.Errorf("error creating request")
+					},
+				})
+				return client, nil
+			},
+			wantErr: true,
+			Err:     fmt.Errorf("error creating request"),
+		},
+		{
+			name: "when the http request fails",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						return nil, fmt.Errorf("error making request")
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						return &http.Request{}, nil
+					},
+				})
+				return client, nil
+			},
+			wantErr: true,
+			Err:     fmt.Errorf("error making request"),
+		},
+		{
+			name: "when the request is successful",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						resp := &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       nil,
+						}
+						return resp, nil
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						assert.Equal(t, "GET", method)
+						assert.Equal(t, "2.0/repositories/workspace-uuid/repo-slug/default-reviewers", path)
+						return &http.Request{}, nil
+					},
+				})
+
+				return client, &models.ResponseScheme{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+					},
+				}
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, _ := testCase.on(t)
+
+			gotResult, gotResponse, err := client.ListDefaultReviewers(testCase.args.ctx, testCase.args.workspace, testCase.args.repoSlug)
+
+			if testCase.wantErr {
+				assert.Error(t, err)
+				assert.EqualError(t, err, testCase.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func TestRepositoryService_ListPullRequests(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		workspace string
+		repoSlug  string
+	}
+
+	testCases := []struct {
+		name    string
+		args    args
+		on      func(*testing.T) (*RepositoryService, *models.ResponseScheme)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the workspace is not provided",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(nil)
+				return client, nil
+			},
+			wantErr: true,
+			Err:     models.ErrNoWorkspace,
+		},
+		{
+			name: "when the repository slug is not provided",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(nil)
+				return client, nil
+			},
+			wantErr: true,
+			Err:     models.ErrNoRepository,
+		},
+		{
+			name: "when the http request cannot be created",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						return nil, nil
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						return nil, fmt.Errorf("error creating request")
+					},
+				})
+				return client, nil
+			},
+			wantErr: true,
+			Err:     fmt.Errorf("error creating request"),
+		},
+		{
+			name: "when the http request fails",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						return nil, fmt.Errorf("error making request")
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						return &http.Request{}, nil
+					},
+				})
+				return client, nil
+			},
+			wantErr: true,
+			Err:     fmt.Errorf("error making request"),
+		},
+		{
+			name: "when the request is successful",
+			args: args{
+				ctx:       context.Background(),
+				workspace: "workspace-uuid",
+				repoSlug:  "repo-slug",
+			},
+			on: func(t *testing.T) (*RepositoryService, *models.ResponseScheme) {
+				client := NewRepositoryService(testConnector{
+					requestDoer: func(req *http.Request) (*http.Response, error) {
+						resp := &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       nil,
+						}
+						return resp, nil
+					},
+					requestMaker: func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+						assert.Equal(t, "GET", method)
+						assert.Equal(t, "2.0/repositories/workspace-uuid/repo-slug/pullrequests?state=OPEN%2CMERGED%2CDECLINED%2CSUPERSEDED", path)
+
+						// Verify query parameters
+						u, err := url.Parse(query)
+						assert.NoError(t, err)
+						assert.Equal(t, "", u.Query().Get("state"))
+
+						return &http.Request{}, nil
+					},
+				})
+
+				return client, &models.ResponseScheme{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+					},
+				}
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, _ := testCase.on(t)
+
+			gotResult, gotResponse, err := client.ListPullRequests(testCase.args.ctx, testCase.args.workspace, testCase.args.repoSlug)
+
+			if testCase.wantErr {
+				assert.Error(t, err)
+				assert.EqualError(t, err, testCase.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+// testConnector is a mock connector for testing
+type testConnector struct {
+	requestMaker func(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error)
+	requestDoer  func(req *http.Request) (*http.Response, error)
+}
+
+func (t testConnector) NewRequest(ctx context.Context, method, path, query string, body interface{}) (*http.Request, error) {
+	return t.requestMaker(ctx, method, path, query, body)
+}
+
+func (t testConnector) Call(req *http.Request, v interface{}) (*models.ResponseScheme, error) {
+	resp, err := t.requestDoer(req)
+	if err != nil {
+		return nil, err
+	}
+	return &models.ResponseScheme{
+		Response: resp,
+	}, nil
+}

--- a/pkg/infra/models/bitbucket_branch.go
+++ b/pkg/infra/models/bitbucket_branch.go
@@ -5,3 +5,19 @@ type BranchScheme struct {
 	MergeStrategies      []string `json:"merge_strategies"`       // The merge strategies available for the branch.
 	DefaultMergeStrategy string   `json:"default_merge_strategy"` // The default merge strategy used for the branch.
 }
+
+// MainBranchScheme represents the main branch of a repository.
+type MainBranchScheme struct {
+	Name string `json:"name"` // The name of the main branch.
+	Type string `json:"type"` // The type of the main branch.
+}
+
+type OverrideSettingsScheme struct {
+	DefaultMergeStrategy bool `json:"default_merge_strategy"` // Whether to use the default merge strategy.
+	BranchingModel       bool `json:"branching_model"`        // Whether to use the branching model.
+}
+
+type PullRequestBranchScheme struct {
+	Name  string                `json:"name"`
+	Links *WorkspaceLinksScheme `json:"links"`
+}

--- a/pkg/infra/models/bitbucket_group.go
+++ b/pkg/infra/models/bitbucket_group.go
@@ -1,0 +1,11 @@
+package models
+
+// BitbucketGroupScheme represents a Bitbucket group
+type BitbucketGroupScheme struct {
+	Type     string               `json:"type,omitempty"`
+	Name     string               `json:"name,omitempty"`
+	Slug     string               `json:"slug,omitempty"`
+	FullSlug string               `json:"full_slug,omitempty"`
+	Owner    *WorkspaceScheme     `json:"owner,omitempty"`
+	Links    *BitbucketLinkScheme `json:"links,omitempty"`
+}

--- a/pkg/infra/models/bitbucket_repository.go
+++ b/pkg/infra/models/bitbucket_repository.go
@@ -18,26 +18,41 @@ type RepositoryPermissionScheme struct {
 	Repository *RepositoryScheme       `json:"repository,omitempty"` // The repository to which the permission applies.
 }
 
+// RepositoryPageScheme represents a paginated list of repositories
+type RepositoryPageScheme struct {
+	Size     int                 `json:"size"`
+	Page     int                 `json:"page"`
+	Pagelen  int                 `json:"pagelen"`
+	Next     string              `json:"next"`
+	Previous string              `json:"previous"`
+	Values   []*RepositoryScheme `json:"values"`
+}
+
 // RepositoryScheme represents a repository.
 type RepositoryScheme struct {
-	Type        string                  `json:"type,omitempty"`        // The type of the repository.
-	UUID        string                  `json:"uuid,omitempty"`        // The unique identifier of the repository.
-	FullName    string                  `json:"full_name,omitempty"`   // The full name of the repository.
-	IsPrivate   bool                    `json:"is_private,omitempty"`  // Indicates if the repository is private.
-	SCM         string                  `json:"scm,omitempty"`         // The source control management system used by the repository.
-	Name        string                  `json:"name,omitempty"`        // The name of the repository.
-	Description string                  `json:"description,omitempty"` // The description of the repository.
-	CreatedOn   string                  `json:"created_on,omitempty"`  // The creation time of the repository.
-	UpdatedOn   string                  `json:"updated_on,omitempty"`  // The update time of the repository.
-	Size        int                     `json:"size,omitempty"`        // The size of the repository.
-	Language    string                  `json:"language,omitempty"`    // The programming language used in the repository.
-	HasIssues   bool                    `json:"has_issues,omitempty"`  // Indicates if the repository has issues enabled.
-	HasWiki     bool                    `json:"has_wiki,omitempty"`    // Indicates if the repository has a wiki enabled.
-	ForkPolicy  string                  `json:"fork_policy,omitempty"` // The fork policy of the repository.
-	Owner       *BitbucketAccountScheme `json:"owner,omitempty"`       // The owner of the repository.
-	Parent      *RepositoryScheme       `json:"parent,omitempty"`      // The parent repository, if the repository is a fork.
-	Project     BitbucketProjectScheme  `json:"project,omitempty"`     // The project to which the repository belongs.
-	Links       *RepositoryLinksScheme  `json:"links,omitempty"`       // A collection of links related to the repository.
+	Type             string                  `json:"type,omitempty"`              // The type of the repository.
+	UUID             string                  `json:"uuid,omitempty"`              // The unique identifier of the repository.
+	FullName         string                  `json:"full_name,omitempty"`         // The full name of the repository.
+	IsPrivate        bool                    `json:"is_private,omitempty"`        // Indicates if the repository is private.
+	SCM              string                  `json:"scm,omitempty"`               // The source control management system used by the repository.
+	Name             string                  `json:"name,omitempty"`              // The name of the repository.
+	Slug             string                  `json:"slug,omitempty"`              // The slug of the repository.
+	Description      string                  `json:"description,omitempty"`       // The description of the repository.
+	Website          string                  `json:"website,omitempty"`           // The website of the repository.
+	CreatedOn        string                  `json:"created_on,omitempty"`        // The creation time of the repository.
+	UpdatedOn        string                  `json:"updated_on,omitempty"`        // The update time of the repository.
+	Size             int                     `json:"size,omitempty"`              // The size of the repository.
+	Language         string                  `json:"language,omitempty"`          // The programming language used in the repository.
+	HasIssues        bool                    `json:"has_issues,omitempty"`        // Indicates if the repository has issues enabled.
+	HasWiki          bool                    `json:"has_wiki,omitempty"`          // Indicates if the repository has a wiki enabled.
+	ForkPolicy       string                  `json:"fork_policy,omitempty"`       // The fork policy of the repository.
+	Owner            *BitbucketAccountScheme `json:"owner,omitempty"`             // The owner of the repository.
+	Workspace        *WorkspaceScheme        `json:"workspace,omitempty"`         // The workspace to which the repository belongs.
+	Parent           *RepositoryScheme       `json:"parent,omitempty"`            // The parent repository, if the repository is a fork.
+	Project          BitbucketProjectScheme  `json:"project,omitempty"`           // The project to which the repository belongs.
+	MainBranch       *MainBranchScheme       `json:"mainbranch,omitempty"`        // The main branch of the repository.
+	OverrideSettings *OverrideSettingsScheme `json:"override_settings,omitempty"` // The override settings of the repository.
+	Links            *RepositoryLinksScheme  `json:"links,omitempty"`             // A collection of links related to the repository.
 }
 
 // RepositoryLinksScheme represents a collection of links related to a repository.

--- a/pkg/infra/models/branch_restrictions.go
+++ b/pkg/infra/models/branch_restrictions.go
@@ -1,0 +1,30 @@
+package models
+
+// BranchRestrictionsPageScheme represents a paginated list of branch restrictions
+type BranchRestrictionsPageScheme struct {
+	Size     int                        `json:"size"`
+	Page     int                        `json:"page"`
+	Pagelen  int                        `json:"pagelen"`
+	Next     string                     `json:"next"`
+	Previous string                     `json:"previous"`
+	Values   []*BranchRestrictionScheme `json:"values"`
+}
+
+// BranchRestrictionScheme represents a branch restriction rule
+type BranchRestrictionScheme struct {
+	Type            string                        `json:"type,omitempty"`
+	Links           *BranchRestrictionLinksScheme `json:"links,omitempty"`
+	ID              int                           `json:"id,omitempty"`
+	Kind            string                        `json:"kind,omitempty"`
+	BranchMatchKind string                        `json:"branch_match_kind,omitempty"`
+	BranchType      string                        `json:"branch_type,omitempty"`
+	Pattern         string                        `json:"pattern,omitempty"`
+	Value           int                           `json:"value,omitempty"`
+	Users           []*BitbucketAccountScheme     `json:"users,omitempty"`
+	Groups          []*BitbucketGroupScheme       `json:"groups,omitempty"`
+}
+
+// BranchRestrictionLinksScheme represents the links related to a branch restriction
+type BranchRestrictionLinksScheme struct {
+	Self *BitbucketLinkScheme `json:"self,omitempty"`
+}

--- a/pkg/infra/models/default_reviewers.go
+++ b/pkg/infra/models/default_reviewers.go
@@ -1,0 +1,11 @@
+package models
+
+// DefaultReviewersPageScheme represents a paginated list of default reviewers
+type DefaultReviewersPageScheme struct {
+	Size     int                       `json:"size"`
+	Page     int                       `json:"page"`
+	Pagelen  int                       `json:"pagelen"`
+	Next     string                    `json:"next"`
+	Previous string                    `json:"previous"`
+	Values   []*BitbucketAccountScheme `json:"values"`
+}

--- a/pkg/infra/models/pull_requests.go
+++ b/pkg/infra/models/pull_requests.go
@@ -1,0 +1,73 @@
+package models
+
+// PullRequestsResponse represents the response for a list of pull requests
+type PullRequestsResponse struct {
+	Size     int                  `json:"size"`
+	Page     int                  `json:"page"`
+	Pagelen  int                  `json:"pagelen"`
+	Next     string               `json:"next"`
+	Previous string               `json:"previous"`
+	Values   []*PullRequestScheme `json:"values"`
+}
+
+// PullRequestScheme represents a pull request
+type PullRequestScheme struct {
+	CommentCount      int                     `json:"comment_count"`
+	TaskCount         int                     `json:"task_count"`
+	Type              string                  `json:"type"`
+	ID                int                     `json:"id"`
+	Title             string                  `json:"title"`
+	Description       string                  `json:"description"`
+	State             string                  `json:"state"`
+	MergeCommit       *CommitScheme           `json:"merge_commit"`
+	CloseSourceBranch bool                    `json:"close_source_branch"`
+	ClosedBy          *BitbucketAccountScheme `json:"closed_by"`
+	Author            *BitbucketAccountScheme `json:"author"`
+	Reason            string                  `json:"reason"`
+	CreatedOn         string                  `json:"created_on"`
+	UpdatedOn         string                  `json:"updated_on"`
+	Source            *PullRequestRefScheme   `json:"source"`
+	Destination       *PullRequestRefScheme   `json:"destination"`
+	Links             *PullRequestLinksScheme `json:"links"`
+	Summary           *SummaryScheme          `json:"summary"`
+}
+
+// PullRequestRefScheme represents a reference (source/destination) in a pull request
+type PullRequestRefScheme struct {
+	Branch     *PullRequestBranchScheme `json:"branch"`
+	Commit     *CommitScheme            `json:"commit"`
+	Repository *RepositoryScheme        `json:"repository"`
+}
+
+// CommitScheme represents a commit in a pull request
+type CommitScheme struct {
+	Hash    string                `json:"hash"`
+	Type    string                `json:"type"`
+	Message string                `json:"message"`
+	Date    string                `json:"date"`
+	Links   *WorkspaceLinksScheme `json:"links"`
+}
+
+// PullRequestLinksScheme represents the links available in a pull request
+type PullRequestLinksScheme struct {
+	Self           *BitbucketLinkScheme `json:"self"`
+	HTML           *BitbucketLinkScheme `json:"html"`
+	Commits        *BitbucketLinkScheme `json:"commits"`
+	Approve        *BitbucketLinkScheme `json:"approve"`
+	RequestChanges *BitbucketLinkScheme `json:"request-changes"`
+	Diff           *BitbucketLinkScheme `json:"diff"`
+	Diffstat       *BitbucketLinkScheme `json:"diffstat"`
+	Comments       *BitbucketLinkScheme `json:"comments"`
+	Activity       *BitbucketLinkScheme `json:"activity"`
+	Merge          *BitbucketLinkScheme `json:"merge"`
+	Decline        *BitbucketLinkScheme `json:"decline"`
+	Statuses       *BitbucketLinkScheme `json:"statuses"`
+}
+
+// SummaryScheme represents the summary of a pull request
+type SummaryScheme struct {
+	Type   string `json:"type"`
+	Raw    string `json:"raw"`
+	Markup string `json:"markup"`
+	HTML   string `json:"html"`
+}

--- a/service/bitbucket/repository.go
+++ b/service/bitbucket/repository.go
@@ -13,34 +13,39 @@ import (
 // The repo resource allows you to access public repos, or repos that belong to a specific workspace.
 type RepositoryConnector interface {
 
-	// Get returns the object describing this repository.
-	//
-	// GET /2.0/repositories/{workspace}/{repo_slug}
-	Get(ctx context.Context, workspace, repoSlug string) (*models.RepositoryScheme, *models.ResponseScheme, error)
+	// // Get returns the object describing this repository.
+	// //
+	// // GET /2.0/repositories/{workspace}/{repo_slug}
+	// Get(ctx context.Context, workspace, repoSlug string) (*models.RepositoryScheme, *models.ResponseScheme, error)
 
-	// Update updates a Bitbucket repository
-	//
-	// PUT /2.0/repositories/{workspace}/{repo_slug}
-	//
-	// Note: Changing the name of the repository will cause the location to be changed.
-	//
-	// This is because the URL of the repo is derived from the name (a process called slugification).
-	//
-	// In such a scenario, it is possible for the request to fail if the newly created slug conflicts with an existing repository's slug.
-	Update(ctx context.Context, workspace, repoSlug string, payload *models.RepositoryScheme) (*models.RepositoryScheme, *models.ResponseScheme, error)
+	// // Update updates a Bitbucket repository
+	// //
+	// // PUT /2.0/repositories/{workspace}/{repo_slug}
+	// //
+	// // Note: Changing the name of the repository will cause the location to be changed.
+	// //
+	// // This is because the URL of the repo is derived from the name (a process called slugification).
+	// //
+	// // In such a scenario, it is possible for the request to fail if the newly created slug conflicts with an existing repository's slug.
+	// Update(ctx context.Context, workspace, repoSlug string, payload *models.RepositoryScheme) (*models.RepositoryScheme, *models.ResponseScheme, error)
 
-	// Delete deletes the repository. This is an irreversible operation and this does not affect its forks.
-	//
-	// DELETE /2.0/repositories/{workspace}/{repo_slug}
-	Delete(ctx context.Context, workspace, repoSlug, redirectTo string) (*models.ResponseScheme, error)
+	// // Delete deletes the repository. This is an irreversible operation and this does not affect its forks.
+	// //
+	// // DELETE /2.0/repositories/{workspace}/{repo_slug}
+	// Delete(ctx context.Context, workspace, repoSlug, redirectTo string) (*models.ResponseScheme, error)
 
 	// Create creates a new repository.
 	Create(ctx context.Context, workspace, repoSlug string, payload *models.RepositoryScheme) (*models.RepositoryScheme, *models.ResponseScheme, error)
 
-	// Watchers returns a paginated list of all the watchers on the specified repository.
-	//
-	// GET /2.0/repositories/{workspace}/{repo_slug}/watchers
-	Watchers(ctx context.Context, workspace, repoSlug string)
+	// // Watchers returns a paginated list of all the watchers on the specified repository.
+	// //
+	// // GET /2.0/repositories/{workspace}/{repo_slug}/watchers
+	// Watchers(ctx context.Context, workspace, repoSlug string)
+
+	List(ctx context.Context, workspace string) (*models.RepositoryPageScheme, *models.ResponseScheme, error)
+	ListBranchRestrictions(ctx context.Context, workspace, repoSlug string) (*models.BranchRestrictionsPageScheme, *models.ResponseScheme, error)
+	ListDefaultReviewers(ctx context.Context, workspace, repoSlug string) (*models.DefaultReviewersPageScheme, *models.ResponseScheme, error)
+	ListPullRequests(ctx context.Context, workspace, repoSlug string) (*models.PullRequestsResponse, *models.ResponseScheme, error)
 }
 
 // RepositoryForkConnector represents the Bitbucket Cloud repository forks.


### PR DESCRIPTION
* List Repositories
* List Pull Requests
* List Branch Restriction Rules
* List PR default reviewers

Repository Connector in Bitbucket was having function declaration and no definition. This creates problem while implementing our required functions.

I have commented 
* Get
* Update
* Delete
* Watchers

Implemented `Create` Call in repository which was also the declaration but it is not worth as of now to implement the remaining.