### PR TITLE
Fix bitbucket_workspace_membership table AddedOn and LastAccessed

### DIFF
--- a/pkg/infra/models/bitbucket_workspace_membership.go
+++ b/pkg/infra/models/bitbucket_workspace_membership.go
@@ -1,7 +1,5 @@
 package models
 
-import "time"
-
 // WorkspaceMembershipPageScheme represents a paginated list of workspace memberships.
 type WorkspaceMembershipPageScheme struct {
 	Size     int                          `json:"size,omitempty"`     // The number of memberships in the current page.
@@ -17,9 +15,9 @@ type WorkspaceMembershipScheme struct {
 	Links        *WorkspaceMembershipLinksScheme `json:"links,omitempty"`         // The links related to the membership.
 	User         *BitbucketAccountScheme         `json:"user,omitempty"`          // The user who has the membership.
 	Workspace    *WorkspaceScheme                `json:"workspace,omitempty"`     // The workspace to which the membership applies.
-	AddedOn      time.Time                       `json:"added_on,omitempty"`      // The time when the membership was added.
+	AddedOn      string                          `json:"added_on,omitempty"`      // The time when the membership was added.
 	Permission   string                          `json:"permission,omitempty"`    // The level of the membership.
-	LastAccessed time.Time                       `json:"last_accessed,omitempty"` // The last time the membership was accessed.
+	LastAccessed string                          `json:"last_accessed,omitempty"` // The last time the membership was accessed.
 }
 
 // WorkspaceMembershipLinksScheme represents a collection of links related to a workspace membership.


### PR DESCRIPTION
Issue:
AddedOn and LastAccessed comes with random timestamp even though the REST API return null for them.
<img width="560" alt="Screenshot 2025-02-13 at 3 33 40 PM" src="https://github.com/user-attachments/assets/70c706be-bc4e-40c1-83ab-e7851b084af4" />


Fix it to replace AddedOn and LastAccessed to string, similar to other models