### PR TITLE
Add retry and exponential backoff

### DIFF
--- a/admin/api_client_impl.go
+++ b/admin/api_client_impl.go
@@ -28,7 +28,7 @@ const defaultAPIEndpoint = "https://api.atlassian.com/"
 
 // New creates a new instance of Client.
 // It takes a common.HTTPClient as input and returns a pointer to Client and an error.
-func New(httpClient common.HTTPClient, config *ClientConfig) (*Client, error) {
+func New(httpClient common.HTTPClient, config *model.ClientConfig) (*Client, error) {
 	// If no HTTP client is provided, use the default HTTP client.
 	if httpClient == nil {
 		httpClient = http.DefaultClient
@@ -42,7 +42,7 @@ func New(httpClient common.HTTPClient, config *ClientConfig) (*Client, error) {
 
 	// Use default config if not provided
 	if config == nil {
-		config = &ClientConfig{
+		config = &model.ClientConfig{
 			MaxRetries:        5,
 			InitialRetryDelay: 1000,
 			MaxRetryDelay:     10000,
@@ -78,16 +78,6 @@ func New(httpClient common.HTTPClient, config *ClientConfig) (*Client, error) {
 	client.User = internal.NewUserService(client, internal.NewUserTokenService(client))
 
 	return client, nil
-}
-
-// ClientConfig holds configuration options for the Client
-type ClientConfig struct {
-	// MaxRetries is the maximum number of retries for rate limit handling
-	MaxRetries int
-	// InitialRetryDelay is the initial delay between retries in milliseconds
-	InitialRetryDelay time.Duration
-	// MaxRetryDelay is the maximum delay between retries in milliseconds
-	MaxRetryDelay time.Duration
 }
 
 // Client represents a client for interacting with the Atlassian Administration API.

--- a/admin/api_client_impl.go
+++ b/admin/api_client_impl.go
@@ -36,8 +36,8 @@ func New(httpClient common.HTTPClient, config *model.ClientConfig) (*Client, err
 	if config == nil {
 		config = &model.ClientConfig{
 			MaxRetries:        5,
-			InitialRetryDelay: 1000,
-			MaxRetryDelay:     10000,
+			InitialRetryDelay: time.Duration(1) * time.Minute,
+			MaxRetryDelay:     time.Duration(10) * time.Minute,
 		}
 	}
 

--- a/admin/api_client_impl.go
+++ b/admin/api_client_impl.go
@@ -228,6 +228,9 @@ func (c *Client) processResponse(response *http.Response, structure interface{})
 		case http.StatusBadRequest:
 			return res, model.ErrBadRequest
 
+		case http.StatusTooManyRequests:
+			return res, model.ErrRateLimited
+
 		default:
 			return res, model.ErrInvalidStatusCode
 		}

--- a/admin/api_client_impl.go
+++ b/admin/api_client_impl.go
@@ -6,20 +6,29 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
+	"sync"
+	"time"
 
 	"github.com/ctreminiom/go-atlassian/v2/admin/internal"
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/v2/service/common"
 )
 
+// timerPool provides a pool of timers for rate limit retries
+var timerPool = sync.Pool{
+	New: func() interface{} {
+		return time.NewTimer(0)
+	},
+}
+
 const defaultAPIEndpoint = "https://api.atlassian.com/"
 
 // New creates a new instance of Client.
 // It takes a common.HTTPClient as input and returns a pointer to Client and an error.
-func New(httpClient common.HTTPClient) (*Client, error) {
-
+func New(httpClient common.HTTPClient, config *ClientConfig) (*Client, error) {
 	// If no HTTP client is provided, use the default HTTP client.
 	if httpClient == nil {
 		httpClient = http.DefaultClient
@@ -31,10 +40,22 @@ func New(httpClient common.HTTPClient) (*Client, error) {
 		return nil, err
 	}
 
+	// Use default config if not provided
+	if config == nil {
+		config = &ClientConfig{
+			MaxRetries:        5,
+			InitialRetryDelay: 1000,
+			MaxRetryDelay:     10000,
+		}
+	}
+
 	// Initialize the Client struct with the provided HTTP client and parsed URL.
 	client := &Client{
-		HTTP: httpClient,
-		Site: u,
+		HTTP:              httpClient,
+		Site:              u,
+		MaxRetries:        config.MaxRetries,
+		InitialRetryDelay: config.InitialRetryDelay,
+		MaxRetryDelay:     config.MaxRetryDelay,
 	}
 
 	// Initialize the Authentication service.
@@ -59,12 +80,28 @@ func New(httpClient common.HTTPClient) (*Client, error) {
 	return client, nil
 }
 
+// ClientConfig holds configuration options for the Client
+type ClientConfig struct {
+	// MaxRetries is the maximum number of retries for rate limit handling
+	MaxRetries int
+	// InitialRetryDelay is the initial delay between retries in milliseconds
+	InitialRetryDelay time.Duration
+	// MaxRetryDelay is the maximum delay between retries in milliseconds
+	MaxRetryDelay time.Duration
+}
+
 // Client represents a client for interacting with the Atlassian Administration API.
 type Client struct {
 	// HTTP is the HTTP client used for making requests.
 	HTTP common.HTTPClient
 	// Site is the base URL for the API.
 	Site *url.URL
+	// MaxRetries is the maximum number of retries for rate limit handling.
+	MaxRetries int
+	// InitialRetryDelay is the initial delay between retries.
+	InitialRetryDelay time.Duration
+	// MaxRetryDelay is the maximum delay between retries.
+	MaxRetryDelay time.Duration
 	// Auth is the authentication service.
 	Auth common.Authentication
 	// Organization is the service for organization-related operations.
@@ -129,15 +166,48 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr, contentType str
 // It takes an *http.Request and a structure to unmarshal the response into.
 // It returns a pointer to model.ResponseScheme and an error.
 func (c *Client) Call(request *http.Request, structure interface{}) (*model.ResponseScheme, error) {
+	retryCount := 0
+	ctx := request.Context()
 
-	// Perform the HTTP request.
-	response, err := c.HTTP.Do(request)
-	if err != nil {
-		return nil, err
+	for {
+		response, err := c.HTTP.Do(request)
+		if err != nil {
+			return nil, err
+		}
+
+		// If rate limit exceeded, sleep with exponential backoff
+		if response.StatusCode == http.StatusTooManyRequests {
+			delay := c.InitialRetryDelay * time.Millisecond
+			// Use bit shifting for exponential backoff (1 << retryCount)
+			delay = delay * (1 << uint(retryCount))
+			if delay > c.MaxRetryDelay {
+				delay = c.MaxRetryDelay
+			}
+			log.Printf("Rate limit exceeded, sleeping for %v milliseconds", delay.Milliseconds())
+
+			// Get timer from pool and reset it
+			timer := timerPool.Get().(*time.Timer)
+			timer.Reset(delay)
+			defer timerPool.Put(timer)
+
+			// Wait for either context cancellation or timer
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+				// Timer completed successfully
+			}
+
+			retryCount++
+			if retryCount > c.MaxRetries {
+				return c.processResponse(response, structure)
+			}
+			continue
+		}
+
+		return c.processResponse(response, structure)
 	}
-
-	// Process the HTTP response.
-	return c.processResponse(response, structure)
 }
 
 func (c *Client) processResponse(response *http.Response, structure interface{}) (*model.ResponseScheme, error) {

--- a/admin/api_client_impl_test.go
+++ b/admin/api_client_impl_test.go
@@ -190,7 +190,7 @@ func TestClient_Call(t *testing.T) {
 				Bytes:    *bytes.NewBufferString("Rate limit exceeded"),
 			},
 			wantErr: true,
-			Err:     model.ErrInvalidStatusCode,
+			Err:     model.ErrRateLimited,
 		},
 		{
 			name: "when context is cancelled during rate limit retry",

--- a/admin/api_client_impl_test.go
+++ b/admin/api_client_impl_test.go
@@ -299,7 +299,7 @@ func TestClient_Call(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			config := &ClientConfig{
+			config := &model.ClientConfig{
 				MaxRetries:        5,
 				InitialRetryDelay: 1000,
 				MaxRetryDelay:     10000,
@@ -432,7 +432,7 @@ func TestClient_NewRequest(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			config := &ClientConfig{
+			config := &model.ClientConfig{
 				MaxRetries:        5,
 				InitialRetryDelay: 1000,
 				MaxRetryDelay:     10000,
@@ -523,7 +523,7 @@ func TestClient_processResponse(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			config := &ClientConfig{
+			config := &model.ClientConfig{
 				MaxRetries:        5,
 				InitialRetryDelay: 1000,
 				MaxRetryDelay:     10000,
@@ -564,7 +564,7 @@ func TestNew(t *testing.T) {
 	mockClient.Auth.SetUserAgent("aaa")
 
 	// Create a client with custom config
-	customConfig := &ClientConfig{
+	customConfig := &model.ClientConfig{
 		MaxRetries:        10,
 		InitialRetryDelay: 2000,
 		MaxRetryDelay:     20000,
@@ -576,7 +576,7 @@ func TestNew(t *testing.T) {
 
 	type args struct {
 		httpClient common.HTTPClient
-		config     *ClientConfig
+		config     *model.ClientConfig
 	}
 
 	testCases := []struct {

--- a/admin/api_client_impl_test.go
+++ b/admin/api_client_impl_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/ctreminiom/go-atlassian/v2/admin/internal"
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
@@ -18,10 +19,18 @@ import (
 )
 
 func TestClient_Call(t *testing.T) {
-
 	expectedResponse := &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader("Hello, world!")),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    &url.URL{},
+		},
+	}
+
+	rateLimitResponse := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       io.NopCloser(strings.NewReader("Rate limit exceeded")),
 		Request: &http.Request{
 			Method: http.MethodGet,
 			URL:    &url.URL{},
@@ -64,6 +73,19 @@ func TestClient_Call(t *testing.T) {
 		},
 	}
 
+	// Create test requests
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	reqWithTimeout, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	type fields struct {
 		HTTP common.HTTPClient
 		Site *url.URL
@@ -86,16 +108,13 @@ func TestClient_Call(t *testing.T) {
 		{
 			name: "when the parameters are correct",
 			on: func(fields *fields) {
-
 				client := mocks.NewHTTPClient(t)
-
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", mock.AnythingOfType("*http.Request")).
 					Return(expectedResponse, nil)
-
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -106,20 +125,99 @@ func TestClient_Call(t *testing.T) {
 			},
 			wantErr: false,
 		},
-
 		{
-			name: "when the response status is a bad request",
+			name: "when rate limit is hit and retry succeeds",
 			on: func(fields *fields) {
-
 				client := mocks.NewHTTPClient(t)
-
-				client.On("Do", (*http.Request)(nil)).
-					Return(badRequestResponse, nil)
-
+				// First call returns rate limit
+				client.On("Do", mock.AnythingOfType("*http.Request")).
+					Return(&http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Body:       io.NopCloser(strings.NewReader("Rate limit exceeded")),
+						Request: &http.Request{
+							Method: http.MethodGet,
+							URL:    &url.URL{},
+						},
+					}, nil).
+					Once()
+				// Second call returns success
+				client.On("Do", mock.AnythingOfType("*http.Request")).
+					Return(&http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader("Hello, world!")),
+						Request: &http.Request{
+							Method: http.MethodGet,
+							URL:    &url.URL{},
+						},
+					}, nil)
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
+				structure: nil,
+			},
+			want: &model.ResponseScheme{
+				Response: &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("Hello, world!")),
+					Request: &http.Request{
+						Method: http.MethodGet,
+						URL:    &url.URL{},
+					},
+				},
+				Code:   http.StatusOK,
+				Method: http.MethodGet,
+				Bytes:  *bytes.NewBufferString("Hello, world!"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "when rate limit is hit and max retries exceeded",
+			on: func(fields *fields) {
+				client := mocks.NewHTTPClient(t)
+				client.On("Do", mock.AnythingOfType("*http.Request")).
+					Return(rateLimitResponse, nil)
+				fields.HTTP = client
+			},
+			args: args{
+				request:   req,
+				structure: nil,
+			},
+			want: &model.ResponseScheme{
+				Response: rateLimitResponse,
+				Code:     http.StatusTooManyRequests,
+				Method:   http.MethodGet,
+				Bytes:    *bytes.NewBufferString("Rate limit exceeded"),
+			},
+			wantErr: true,
+			Err:     model.ErrInvalidStatusCode,
+		},
+		{
+			name: "when context is cancelled during rate limit retry",
+			on: func(fields *fields) {
+				client := mocks.NewHTTPClient(t)
+				client.On("Do", mock.AnythingOfType("*http.Request")).
+					Return(rateLimitResponse, nil)
+				fields.HTTP = client
+			},
+			args: args{
+				request:   reqWithTimeout,
+				structure: nil,
+			},
+			want:    nil,
+			wantErr: true,
+			Err:     context.DeadlineExceeded,
+		},
+		{
+			name: "when the response status is a bad request",
+			on: func(fields *fields) {
+				client := mocks.NewHTTPClient(t)
+				client.On("Do", mock.AnythingOfType("*http.Request")).
+					Return(badRequestResponse, nil)
+				fields.HTTP = client
+			},
+			args: args{
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -131,20 +229,16 @@ func TestClient_Call(t *testing.T) {
 			wantErr: true,
 			Err:     model.ErrBadRequest,
 		},
-
 		{
 			name: "when the response status is an internal service error",
 			on: func(fields *fields) {
-
 				client := mocks.NewHTTPClient(t)
-
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", mock.AnythingOfType("*http.Request")).
 					Return(internalServerResponse, nil)
-
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -156,20 +250,16 @@ func TestClient_Call(t *testing.T) {
 			wantErr: true,
 			Err:     model.ErrInternal,
 		},
-
 		{
 			name: "when the response status is a not found",
 			on: func(fields *fields) {
-
 				client := mocks.NewHTTPClient(t)
-
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", mock.AnythingOfType("*http.Request")).
 					Return(notFoundResponse, nil)
-
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -181,20 +271,16 @@ func TestClient_Call(t *testing.T) {
 			wantErr: true,
 			Err:     model.ErrNotFound,
 		},
-
 		{
 			name: "when the response status is unauthorized",
 			on: func(fields *fields) {
-
 				client := mocks.NewHTTPClient(t)
-
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", mock.AnythingOfType("*http.Request")).
 					Return(unauthorizedResponse, nil)
-
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -209,31 +295,38 @@ func TestClient_Call(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-
 			if testCase.on != nil {
 				testCase.on(&testCase.fields)
 			}
 
+			config := &ClientConfig{
+				MaxRetries:        5,
+				InitialRetryDelay: 1000,
+				MaxRetryDelay:     10000,
+			}
+
 			c := &Client{
-				HTTP: testCase.fields.HTTP,
-				Site: testCase.fields.Site,
+				HTTP:              testCase.fields.HTTP,
+				Site:              testCase.fields.Site,
+				MaxRetries:        config.MaxRetries,
+				InitialRetryDelay: config.InitialRetryDelay,
+				MaxRetryDelay:     config.MaxRetryDelay,
 			}
 
 			got, err := c.Call(testCase.args.request, testCase.args.structure)
 
 			if testCase.wantErr {
-
 				if err != nil {
 					t.Logf("error returned: %v", err.Error())
 				}
-
 				assert.EqualError(t, err, testCase.Err.Error())
-
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, got, testCase.want)
+				assert.NotNil(t, got)
+				assert.Equal(t, testCase.want.Code, got.Code)
+				assert.Equal(t, testCase.want.Method, got.Method)
+				assert.Equal(t, testCase.want.Bytes.String(), got.Bytes.String())
 			}
-
 		})
 	}
 }
@@ -339,11 +432,19 @@ func TestClient_NewRequest(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			config := &ClientConfig{
+				MaxRetries:        5,
+				InitialRetryDelay: 1000,
+				MaxRetryDelay:     10000,
+			}
 
 			c := &Client{
-				HTTP: testCase.fields.HTTP,
-				Auth: testCase.fields.Auth,
-				Site: testCase.fields.Site,
+				HTTP:              testCase.fields.HTTP,
+				Auth:              testCase.fields.Auth,
+				Site:              testCase.fields.Site,
+				MaxRetries:        config.MaxRetries,
+				InitialRetryDelay: config.InitialRetryDelay,
+				MaxRetryDelay:     config.MaxRetryDelay,
 			}
 
 			got, err := c.NewRequest(
@@ -355,18 +456,14 @@ func TestClient_NewRequest(t *testing.T) {
 			)
 
 			if testCase.wantErr {
-
 				if err != nil {
 					t.Logf("error returned: %v", err.Error())
 				}
-
 				assert.Error(t, err)
 			} else {
-
 				assert.NoError(t, err)
 				assert.NotEqual(t, got, nil)
 			}
-
 		})
 	}
 }
@@ -426,36 +523,39 @@ func TestClient_processResponse(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			config := &ClientConfig{
+				MaxRetries:        5,
+				InitialRetryDelay: 1000,
+				MaxRetryDelay:     10000,
+			}
 
 			c := &Client{
-				HTTP: testCase.fields.HTTP,
-				Site: testCase.fields.Site,
-				Auth: testCase.fields.Authentication,
+				HTTP:              testCase.fields.HTTP,
+				Site:              testCase.fields.Site,
+				Auth:              testCase.fields.Authentication,
+				MaxRetries:        config.MaxRetries,
+				InitialRetryDelay: config.InitialRetryDelay,
+				MaxRetryDelay:     config.MaxRetryDelay,
 			}
 
 			got, err := c.processResponse(testCase.args.response, testCase.args.structure)
 
 			if testCase.wantErr {
-
 				if err != nil {
 					t.Logf("error returned: %v", err.Error())
 				}
-
 				assert.Error(t, err)
 				assert.EqualError(t, err, testCase.Err.Error())
-
 			} else {
 				assert.NoError(t, err)
 				assert.NotEqual(t, got, nil)
 			}
-
 		})
 	}
 }
 
 func TestNew(t *testing.T) {
-
-	mockClient, err := New(http.DefaultClient)
+	mockClient, err := New(http.DefaultClient, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -463,9 +563,20 @@ func TestNew(t *testing.T) {
 	mockClient.Auth.SetBasicAuth("test", "test")
 	mockClient.Auth.SetUserAgent("aaa")
 
+	// Create a client with custom config
+	customConfig := &ClientConfig{
+		MaxRetries:        10,
+		InitialRetryDelay: 2000,
+		MaxRetryDelay:     20000,
+	}
+	customClient, err := New(http.DefaultClient, customConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	type args struct {
 		httpClient common.HTTPClient
-		site       string
+		config     *ClientConfig
 	}
 
 	testCases := []struct {
@@ -475,35 +586,42 @@ func TestNew(t *testing.T) {
 		wantErr bool
 		Err     error
 	}{
-
 		{
-			name: "when the parameters are correct",
+			name: "when using default config",
 			args: args{
 				httpClient: http.DefaultClient,
-				site:       "https://ctreminiom.atlassian.net",
+				config:     nil,
 			},
 			want:    mockClient,
+			wantErr: false,
+		},
+		{
+			name: "when using custom config",
+			args: args{
+				httpClient: http.DefaultClient,
+				config:     customConfig,
+			},
+			want:    customClient,
 			wantErr: false,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-
-			gotClient, err := New(testCase.args.httpClient)
+			gotClient, err := New(testCase.args.httpClient, testCase.args.config)
 
 			if testCase.wantErr {
-
 				if err != nil {
 					t.Logf("error returned: %v", err.Error())
 				}
-
 				assert.Error(t, err)
 				assert.EqualError(t, err, testCase.Err.Error())
-
 			} else {
 				assert.NoError(t, err)
-				assert.NotEqual(t, gotClient, nil)
+				assert.NotNil(t, gotClient)
+				assert.Equal(t, testCase.want.MaxRetries, gotClient.MaxRetries)
+				assert.Equal(t, testCase.want.InitialRetryDelay, gotClient.InitialRetryDelay)
+				assert.Equal(t, testCase.want.MaxRetryDelay, gotClient.MaxRetryDelay)
 			}
 		})
 	}

--- a/bitbucket/api_client_impl.go
+++ b/bitbucket/api_client_impl.go
@@ -28,18 +28,8 @@ var timerPool = sync.Pool{
 // DefaultBitbucketSite is the default Bitbucket API site.
 const DefaultBitbucketSite = "https://api.bitbucket.org"
 
-// ClientConfig holds configuration options for the Client
-type ClientConfig struct {
-	// MaxRetries is the maximum number of retries for rate limit handling
-	MaxRetries int
-	// InitialRetryDelay is the initial delay between retries in milliseconds
-	InitialRetryDelay time.Duration
-	// MaxRetryDelay is the maximum delay between retries in milliseconds
-	MaxRetryDelay time.Duration
-}
-
 // New creates a new Bitbucket API client.
-func New(httpClient common.HTTPClient, site string, config *ClientConfig) (*Client, error) {
+func New(httpClient common.HTTPClient, site string, config *models.ClientConfig) (*Client, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
@@ -59,7 +49,7 @@ func New(httpClient common.HTTPClient, site string, config *ClientConfig) (*Clie
 
 	// Use default config if not provided
 	if config == nil {
-		config = &ClientConfig{
+		config = &models.ClientConfig{
 			MaxRetries:        5,
 			InitialRetryDelay: 1000,
 			MaxRetryDelay:     10000,

--- a/bitbucket/api_client_impl.go
+++ b/bitbucket/api_client_impl.go
@@ -215,6 +215,9 @@ func (c *Client) processResponse(response *http.Response, structure interface{})
 		case http.StatusBadRequest:
 			return res, models.ErrBadRequest
 
+		case http.StatusTooManyRequests:
+			return res, models.ErrRateLimited
+
 		default:
 			return res, models.ErrInvalidStatusCode
 		}

--- a/bitbucket/api_client_impl.go
+++ b/bitbucket/api_client_impl.go
@@ -43,8 +43,8 @@ func New(httpClient common.HTTPClient, site string, config *models.ClientConfig)
 	if config == nil {
 		config = &models.ClientConfig{
 			MaxRetries:        5,
-			InitialRetryDelay: 1000,
-			MaxRetryDelay:     10000,
+			InitialRetryDelay: time.Duration(1) * time.Minute,
+			MaxRetryDelay:     time.Duration(10) * time.Minute,
 		}
 	}
 

--- a/bitbucket/api_client_impl_test.go
+++ b/bitbucket/api_client_impl_test.go
@@ -303,7 +303,7 @@ func TestClient_Call(t *testing.T) {
 				Bytes:  *bytes.NewBufferString("Rate limit exceeded"),
 			},
 			wantErr: true,
-			Err:     model.ErrInvalidStatusCode,
+			Err:     model.ErrRateLimited,
 		},
 
 		{

--- a/pkg/infra/models/client_config.go
+++ b/pkg/infra/models/client_config.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+// ClientConfig holds configuration options for the Client
+type ClientConfig struct {
+	// MaxRetries is the maximum number of retries for rate limit handling
+	MaxRetries int
+	// InitialRetryDelay is the initial delay between retries in milliseconds
+	InitialRetryDelay time.Duration
+	// MaxRetryDelay is the maximum delay between retries in milliseconds
+	MaxRetryDelay time.Duration
+}

--- a/pkg/infra/models/errors.go
+++ b/pkg/infra/models/errors.go
@@ -133,6 +133,7 @@ var (
 	ErrUnauthorized                   = errors.New("client: atlassian insufficient permissions")
 	ErrInternal                       = errors.New("client: atlassian internal error")
 	ErrBadRequest                     = errors.New("client: atlassian invalid payload")
+	ErrRateLimited                    = errors.New("client: atlassian rate limited")
 	ErrNoSite                         = errors.New("client: no atlassian site set")
 	ErrNoFloatType                    = errors.New("custom-field: no float type set")
 	ErrNoSprintType                   = errors.New("custom-field: no sprint type found")


### PR DESCRIPTION
Add retry and exponential backoff at admin and bitbucket clients, with configurable retry configs.
Make use of timer for sleep process for better performance.
Add UTs for various cases of rate limiting.


Testing screenshots where process went to exponential backoff sleep after hitting rate limits(start at 1m sleep, goes till 10 mins):
<img width="910" alt="Screenshot 2025-04-04 at 4 21 34 PM" src="https://github.com/user-attachments/assets/ff3d6e1b-687b-43b8-bed1-0046df8f0aee" />
<img width="1083" alt="Screenshot 2025-04-04 at 4 30 54 PM" src="https://github.com/user-attachments/assets/8e6a0767-144d-4a69-9f06-b45e204c0b13" />
<img width="1055" alt="Screenshot 2025-04-04 at 4 13 48 PM" src="https://github.com/user-attachments/assets/4ac91fa8-cec4-4bd9-8721-863b0790ca16" />
