### PR TITLE
Add ClientConfig-driven 429 retry to Jira clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ func main() {
        token = os.Getenv("TOKEN")  
     )  
   
-    atlassian, err := v3.New(nil, host)  
+    atlassian, err := v3.New(nil, host, nil)  
     if err != nil {  
        log.Fatal(err)  
     }  

--- a/jira/agile/api_client_impl.go
+++ b/jira/agile/api_client_impl.go
@@ -6,16 +6,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/ctreminiom/go-atlassian/v2/jira/agile/internal"
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/v2/service/common"
 )
 
-func New(httpClient common.HTTPClient, site string) (*Client, error) {
+func New(httpClient common.HTTPClient, site string, config *model.ClientConfig) (*Client, error) {
 
 	if httpClient == nil {
 		httpClient = http.DefaultClient
@@ -34,9 +36,21 @@ func New(httpClient common.HTTPClient, site string) (*Client, error) {
 		return nil, err
 	}
 
+	// Use default config if not provided
+	if config == nil {
+		config = &model.ClientConfig{
+			MaxRetries:        5,
+			InitialRetryDelay: time.Duration(1) * time.Minute,
+			MaxRetryDelay:     time.Duration(10) * time.Minute,
+		}
+	}
+
 	client := &Client{
-		HTTP: httpClient,
-		Site: u,
+		HTTP:              httpClient,
+		Site:              u,
+		MaxRetries:        config.MaxRetries,
+		InitialRetryDelay: config.InitialRetryDelay,
+		MaxRetryDelay:     config.MaxRetryDelay,
 	}
 
 	client.Board = internal.NewBoardService(client, "1.0")
@@ -49,13 +63,16 @@ func New(httpClient common.HTTPClient, site string) (*Client, error) {
 }
 
 type Client struct {
-	HTTP    common.HTTPClient
-	Site    *url.URL
-	Auth    common.Authentication
-	Board   *internal.BoardService
-	Backlog *internal.BoardBacklogService
-	Epic    *internal.EpicService
-	Sprint  *internal.SprintService
+	HTTP              common.HTTPClient
+	Site              *url.URL
+	MaxRetries        int
+	InitialRetryDelay time.Duration
+	MaxRetryDelay     time.Duration
+	Auth              common.Authentication
+	Board             *internal.BoardService
+	Backlog           *internal.BoardBacklogService
+	Epic              *internal.EpicService
+	Sprint            *internal.SprintService
 }
 
 func (c *Client) NewRequest(ctx context.Context, method, urlStr, contentType string, body interface{}) (*http.Request, error) {
@@ -104,13 +121,48 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr, contentType str
 }
 
 func (c *Client) Call(request *http.Request, structure interface{}) (*model.ResponseScheme, error) {
+	retryCount := 0
+	ctx := request.Context()
 
-	response, err := c.HTTP.Do(request)
-	if err != nil {
-		return nil, err
+	for {
+		response, err := c.HTTP.Do(request)
+		if err != nil {
+			return nil, err
+		}
+
+		// If rate limit exceeded, sleep with exponential backoff
+		if response.StatusCode == http.StatusTooManyRequests {
+			delay := c.InitialRetryDelay
+			// Use bit shifting for exponential backoff (1 << retryCount)
+			delay = delay * (1 << uint(retryCount))
+			if delay > c.MaxRetryDelay {
+				delay = c.MaxRetryDelay
+			}
+			log.Printf("Rate limit exceeded, sleeping for %v request %v", delay, request.URL.String())
+
+			// Get timer
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
+
+			// Wait for either context cancellation or timer
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+				log.Printf("Timer completed successfully")
+				// Timer completed successfully
+			}
+
+			retryCount++
+			if retryCount > c.MaxRetries {
+				return c.processResponse(response, structure)
+			}
+			continue
+		}
+
+		return c.processResponse(response, structure)
 	}
-
-	return c.processResponse(response, structure)
 }
 
 func (c *Client) processResponse(response *http.Response, structure interface{}) (*model.ResponseScheme, error) {

--- a/jira/agile/api_client_impl_test.go
+++ b/jira/agile/api_client_impl_test.go
@@ -65,6 +65,11 @@ func TestClient_Call(t *testing.T) {
 		},
 	}
 
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	type fields struct {
 		HTTP    common.HTTPClient
 		Site    *url.URL
@@ -94,13 +99,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(expectedResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -118,13 +123,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(badRequestResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -143,13 +148,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(internalServerResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -168,13 +173,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(notFoundResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -193,13 +198,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(unauthorizedResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -468,7 +473,7 @@ func TestClient_processResponse(t *testing.T) {
 
 func TestNew(t *testing.T) {
 
-	mockClient, err := New(http.DefaultClient, "https://ctreminiom.atlassian.net")
+	mockClient, err := New(http.DefaultClient, "https://ctreminiom.atlassian.net", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,9 +481,9 @@ func TestNew(t *testing.T) {
 	mockClient.Auth.SetBasicAuth("test", "test")
 	mockClient.Auth.SetUserAgent("aaa")
 
-	invalidURLClientMocked, _ := New(nil, " https://zhidao.baidu.com/special/view?id=sd&preview=1")
+	invalidURLClientMocked, _ := New(nil, " https://zhidao.baidu.com/special/view?id=sd&preview=1", nil)
 
-	noURLClientMocked, _ := New(nil, "")
+	noURLClientMocked, _ := New(nil, "", nil)
 
 	type args struct {
 		httpClient common.HTTPClient
@@ -528,7 +533,7 @@ func TestNew(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 
-			gotClient, err := New(testCase.args.httpClient, testCase.args.site)
+			gotClient, err := New(testCase.args.httpClient, testCase.args.site, nil)
 
 			if testCase.wantErr {
 

--- a/jira/sm/api_client_impl.go
+++ b/jira/sm/api_client_impl.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/ctreminiom/go-atlassian/v2/jira/sm/internal"
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
@@ -17,7 +19,7 @@ import (
 
 const defaultServiceManagementVersion = "latest"
 
-func New(httpClient common.HTTPClient, site string) (*Client, error) {
+func New(httpClient common.HTTPClient, site string, config *model.ClientConfig) (*Client, error) {
 
 	if httpClient == nil {
 		httpClient = http.DefaultClient
@@ -36,9 +38,21 @@ func New(httpClient common.HTTPClient, site string) (*Client, error) {
 		return nil, err
 	}
 
+	// Use default config if not provided
+	if config == nil {
+		config = &model.ClientConfig{
+			MaxRetries:        5,
+			InitialRetryDelay: time.Duration(1) * time.Minute,
+			MaxRetryDelay:     time.Duration(10) * time.Minute,
+		}
+	}
+
 	client := &Client{
-		HTTP: httpClient,
-		Site: u,
+		HTTP:              httpClient,
+		Site:              u,
+		MaxRetries:        config.MaxRetries,
+		InitialRetryDelay: config.InitialRetryDelay,
+		MaxRetryDelay:     config.MaxRetryDelay,
 	}
 
 	client.Auth = internal.NewAuthenticationService(client)
@@ -78,16 +92,19 @@ func New(httpClient common.HTTPClient, site string) (*Client, error) {
 }
 
 type Client struct {
-	HTTP          common.HTTPClient
-	Site          *url.URL
-	Auth          common.Authentication
-	Customer      *internal.CustomerService
-	Info          *internal.InfoService
-	Knowledgebase *internal.KnowledgebaseService
-	Organization  *internal.OrganizationService
-	Request       *internal.RequestService
-	ServiceDesk   *internal.ServiceDeskService
-	WorkSpace     *internal.WorkSpaceService
+	HTTP              common.HTTPClient
+	Site              *url.URL
+	MaxRetries        int
+	InitialRetryDelay time.Duration
+	MaxRetryDelay     time.Duration
+	Auth              common.Authentication
+	Customer          *internal.CustomerService
+	Info              *internal.InfoService
+	Knowledgebase     *internal.KnowledgebaseService
+	Organization      *internal.OrganizationService
+	Request           *internal.RequestService
+	ServiceDesk       *internal.ServiceDeskService
+	WorkSpace         *internal.WorkSpaceService
 }
 
 func (c *Client) NewRequest(ctx context.Context, method, urlStr, contentType string, body interface{}) (*http.Request, error) {
@@ -149,13 +166,48 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr, contentType str
 }
 
 func (c *Client) Call(request *http.Request, structure interface{}) (*model.ResponseScheme, error) {
+	retryCount := 0
+	ctx := request.Context()
 
-	response, err := c.HTTP.Do(request)
-	if err != nil {
-		return nil, err
+	for {
+		response, err := c.HTTP.Do(request)
+		if err != nil {
+			return nil, err
+		}
+
+		// If rate limit exceeded, sleep with exponential backoff
+		if response.StatusCode == http.StatusTooManyRequests {
+			delay := c.InitialRetryDelay
+			// Use bit shifting for exponential backoff (1 << retryCount)
+			delay = delay * (1 << uint(retryCount))
+			if delay > c.MaxRetryDelay {
+				delay = c.MaxRetryDelay
+			}
+			log.Printf("Rate limit exceeded, sleeping for %v request %v", delay, request.URL.String())
+
+			// Get timer
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
+
+			// Wait for either context cancellation or timer
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+				log.Printf("Timer completed successfully")
+				// Timer completed successfully
+			}
+
+			retryCount++
+			if retryCount > c.MaxRetries {
+				return c.processResponse(response, structure)
+			}
+			continue
+		}
+
+		return c.processResponse(response, structure)
 	}
-
-	return c.processResponse(response, structure)
 }
 
 func (c *Client) processResponse(response *http.Response, structure interface{}) (*model.ResponseScheme, error) {

--- a/jira/sm/api_client_impl_test.go
+++ b/jira/sm/api_client_impl_test.go
@@ -65,6 +65,11 @@ func TestClient_Call(t *testing.T) {
 		},
 	}
 
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	type fields struct {
 		HTTP common.HTTPClient
 		Site *url.URL
@@ -90,13 +95,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(expectedResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -114,13 +119,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(badRequestResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -139,13 +144,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(internalServerResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -164,13 +169,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(notFoundResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -189,13 +194,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(unauthorizedResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -456,7 +461,7 @@ func TestClient_processResponse(t *testing.T) {
 
 func TestNew(t *testing.T) {
 
-	mockClient, err := New(http.DefaultClient, "https://ctreminiom.atlassian.net")
+	mockClient, err := New(http.DefaultClient, "https://ctreminiom.atlassian.net", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,9 +469,9 @@ func TestNew(t *testing.T) {
 	mockClient.Auth.SetBasicAuth("test", "test")
 	mockClient.Auth.SetUserAgent("aaa")
 
-	invalidURLClientMocked, _ := New(nil, " https://zhidao.baidu.com/special/view?id=sd&preview=1")
+	invalidURLClientMocked, _ := New(nil, " https://zhidao.baidu.com/special/view?id=sd&preview=1", nil)
 
-	noURLClientMocked, _ := New(nil, "")
+	noURLClientMocked, _ := New(nil, "", nil)
 
 	type args struct {
 		httpClient common.HTTPClient
@@ -516,7 +521,7 @@ func TestNew(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 
-			gotClient, err := New(testCase.args.httpClient, testCase.args.site)
+			gotClient, err := New(testCase.args.httpClient, testCase.args.site, nil)
 
 			if testCase.wantErr {
 

--- a/jira/v2/api_client_impl.go
+++ b/jira/v2/api_client_impl.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/ctreminiom/go-atlassian/v2/jira/internal"
 	"github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
@@ -21,7 +23,7 @@ const APIVersion = "2"
 // New creates a new Jira API client.
 // If a nil httpClient is provided, http.DefaultClient will be used.
 // If the site is empty, an error will be returned.
-func New(httpClient common.HTTPClient, site string) (*Client, error) {
+func New(httpClient common.HTTPClient, site string, config *models.ClientConfig) (*Client, error) {
 
 	if httpClient == nil {
 		httpClient = http.DefaultClient
@@ -40,9 +42,21 @@ func New(httpClient common.HTTPClient, site string) (*Client, error) {
 		return nil, err
 	}
 
+	// Use default config if not provided
+	if config == nil {
+		config = &models.ClientConfig{
+			MaxRetries:        5,
+			InitialRetryDelay: time.Duration(1) * time.Minute,
+			MaxRetryDelay:     time.Duration(10) * time.Minute,
+		}
+	}
+
 	client := &Client{
-		HTTP: httpClient,
-		Site: u,
+		HTTP:              httpClient,
+		Site:              u,
+		MaxRetries:        config.MaxRetries,
+		InitialRetryDelay: config.InitialRetryDelay,
+		MaxRetryDelay:     config.MaxRetryDelay,
 	}
 
 	client.Auth = internal.NewAuthenticationService(client)
@@ -404,6 +418,9 @@ type Client struct {
 	HTTP               common.HTTPClient
 	Auth               common.Authentication
 	Site               *url.URL
+	MaxRetries         int
+	InitialRetryDelay  time.Duration
+	MaxRetryDelay      time.Duration
 	Role               *internal.ApplicationRoleService
 	Banner             *internal.AnnouncementBannerService
 	Audit              *internal.AuditRecordService
@@ -480,13 +497,48 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr, contentType str
 	return req, nil
 }
 func (c *Client) Call(request *http.Request, structure interface{}) (*models.ResponseScheme, error) {
+	retryCount := 0
+	ctx := request.Context()
 
-	response, err := c.HTTP.Do(request)
-	if err != nil {
-		return nil, err
+	for {
+		response, err := c.HTTP.Do(request)
+		if err != nil {
+			return nil, err
+		}
+
+		// If rate limit exceeded, sleep with exponential backoff
+		if response.StatusCode == http.StatusTooManyRequests {
+			delay := c.InitialRetryDelay
+			// Use bit shifting for exponential backoff (1 << retryCount)
+			delay = delay * (1 << uint(retryCount))
+			if delay > c.MaxRetryDelay {
+				delay = c.MaxRetryDelay
+			}
+			log.Printf("Rate limit exceeded, sleeping for %v request %v", delay, request.URL.String())
+
+			// Get timer
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
+
+			// Wait for either context cancellation or timer
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+				log.Printf("Timer completed successfully")
+				// Timer completed successfully
+			}
+
+			retryCount++
+			if retryCount > c.MaxRetries {
+				return c.processResponse(response, structure)
+			}
+			continue
+		}
+
+		return c.processResponse(response, structure)
 	}
-
-	return c.processResponse(response, structure)
 }
 
 func (c *Client) processResponse(response *http.Response, structure interface{}) (*models.ResponseScheme, error) {

--- a/jira/v2/api_client_impl_test.go
+++ b/jira/v2/api_client_impl_test.go
@@ -65,6 +65,11 @@ func TestClient_Call(t *testing.T) {
 		},
 	}
 
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	type fields struct {
 		HTTP common.HTTPClient
 		Site *url.URL
@@ -90,13 +95,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(expectedResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -114,13 +119,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(badRequestResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -139,13 +144,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(internalServerResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -164,13 +169,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(notFoundResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -189,13 +194,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(unauthorizedResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -473,7 +478,7 @@ func TestClient_processResponse(t *testing.T) {
 
 func TestNew(t *testing.T) {
 
-	mockClient, err := New(http.DefaultClient, "https://ctreminiom.atlassian.net")
+	mockClient, err := New(http.DefaultClient, "https://ctreminiom.atlassian.net", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,9 +486,9 @@ func TestNew(t *testing.T) {
 	mockClient.Auth.SetBasicAuth("test", "test")
 	mockClient.Auth.SetUserAgent("aaa")
 
-	invalidURLClientMocked, _ := New(nil, " https://zhidao.baidu.com/special/view?id=sd&preview=1")
+	invalidURLClientMocked, _ := New(nil, " https://zhidao.baidu.com/special/view?id=sd&preview=1", nil)
 
-	noURLClientMocked, _ := New(nil, "")
+	noURLClientMocked, _ := New(nil, "", nil)
 
 	type args struct {
 		httpClient common.HTTPClient
@@ -533,7 +538,7 @@ func TestNew(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 
-			gotClient, err := New(testCase.args.httpClient, testCase.args.site)
+			gotClient, err := New(testCase.args.httpClient, testCase.args.site, nil)
 
 			if testCase.wantErr {
 

--- a/jira/v3/api_client_impl.go
+++ b/jira/v3/api_client_impl.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/ctreminiom/go-atlassian/v2/jira/internal"
 	"github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
@@ -21,7 +23,7 @@ const APIVersion = "3"
 // New creates a new Jira API client.
 // If a nil httpClient is provided, http.DefaultClient will be used.
 // If the site is empty, an error will be returned.
-func New(httpClient common.HTTPClient, site string) (*Client, error) {
+func New(httpClient common.HTTPClient, site string, config *models.ClientConfig) (*Client, error) {
 
 	if httpClient == nil {
 		httpClient = http.DefaultClient
@@ -40,9 +42,21 @@ func New(httpClient common.HTTPClient, site string) (*Client, error) {
 		return nil, err
 	}
 
+	// Use default config if not provided
+	if config == nil {
+		config = &models.ClientConfig{
+			MaxRetries:        5,
+			InitialRetryDelay: time.Duration(1) * time.Minute,
+			MaxRetryDelay:     time.Duration(10) * time.Minute,
+		}
+	}
+
 	client := &Client{
-		HTTP: httpClient,
-		Site: u,
+		HTTP:              httpClient,
+		Site:              u,
+		MaxRetries:        config.MaxRetries,
+		InitialRetryDelay: config.InitialRetryDelay,
+		MaxRetryDelay:     config.MaxRetryDelay,
 	}
 
 	client.Auth = internal.NewAuthenticationService(client)
@@ -404,6 +418,9 @@ type Client struct {
 	HTTP               common.HTTPClient
 	Auth               common.Authentication
 	Site               *url.URL
+	MaxRetries         int
+	InitialRetryDelay  time.Duration
+	MaxRetryDelay      time.Duration
 	Audit              *internal.AuditRecordService
 	Role               *internal.ApplicationRoleService
 	Banner             *internal.AnnouncementBannerService
@@ -481,13 +498,48 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr, contentType str
 }
 
 func (c *Client) Call(request *http.Request, structure interface{}) (*models.ResponseScheme, error) {
+	retryCount := 0
+	ctx := request.Context()
 
-	response, err := c.HTTP.Do(request)
-	if err != nil {
-		return nil, err
+	for {
+		response, err := c.HTTP.Do(request)
+		if err != nil {
+			return nil, err
+		}
+
+		// If rate limit exceeded, sleep with exponential backoff
+		if response.StatusCode == http.StatusTooManyRequests {
+			delay := c.InitialRetryDelay
+			// Use bit shifting for exponential backoff (1 << retryCount)
+			delay = delay * (1 << uint(retryCount))
+			if delay > c.MaxRetryDelay {
+				delay = c.MaxRetryDelay
+			}
+			log.Printf("Rate limit exceeded, sleeping for %v request %v", delay, request.URL.String())
+
+			// Get timer
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
+
+			// Wait for either context cancellation or timer
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+				log.Printf("Timer completed successfully")
+				// Timer completed successfully
+			}
+
+			retryCount++
+			if retryCount > c.MaxRetries {
+				return c.processResponse(response, structure)
+			}
+			continue
+		}
+
+		return c.processResponse(response, structure)
 	}
-
-	return c.processResponse(response, structure)
 }
 
 func (c *Client) processResponse(response *http.Response, structure interface{}) (*models.ResponseScheme, error) {

--- a/jira/v3/api_client_impl_test.go
+++ b/jira/v3/api_client_impl_test.go
@@ -65,6 +65,11 @@ func TestClient_Call(t *testing.T) {
 		},
 	}
 
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	type fields struct {
 		HTTP common.HTTPClient
 		Site *url.URL
@@ -90,13 +95,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(expectedResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -114,13 +119,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(badRequestResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -139,13 +144,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(internalServerResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -164,13 +169,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(notFoundResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -189,13 +194,13 @@ func TestClient_Call(t *testing.T) {
 
 				client := mocks.NewHTTPClient(t)
 
-				client.On("Do", (*http.Request)(nil)).
+				client.On("Do", req).
 					Return(unauthorizedResponse, nil)
 
 				fields.HTTP = client
 			},
 			args: args{
-				request:   nil,
+				request:   req,
 				structure: nil,
 			},
 			want: &model.ResponseScheme{
@@ -473,7 +478,7 @@ func TestClient_processResponse(t *testing.T) {
 
 func TestNew(t *testing.T) {
 
-	mockClient, err := New(http.DefaultClient, "https://ctreminiom.atlassian.net")
+	mockClient, err := New(http.DefaultClient, "https://ctreminiom.atlassian.net", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,9 +486,9 @@ func TestNew(t *testing.T) {
 	mockClient.Auth.SetBasicAuth("test", "test")
 	mockClient.Auth.SetUserAgent("aaa")
 
-	invalidURLClientMocked, _ := New(nil, " https://zhidao.baidu.com/special/view?id=sd&preview=1")
+	invalidURLClientMocked, _ := New(nil, " https://zhidao.baidu.com/special/view?id=sd&preview=1", nil)
 
-	noURLClientMocked, _ := New(nil, "")
+	noURLClientMocked, _ := New(nil, "", nil)
 
 	type args struct {
 		httpClient common.HTTPClient
@@ -533,7 +538,7 @@ func TestNew(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 
-			gotClient, err := New(testCase.args.httpClient, testCase.args.site)
+			gotClient, err := New(testCase.args.httpClient, testCase.args.site, nil)
 
 			if testCase.wantErr {
 


### PR DESCRIPTION
## Summary

- Bring the four Jira-family clients (`jira/v2`, `jira/v3`, `jira/agile`, `jira/sm`) to parity with `admin` and `bitbucket`: `New` now accepts a `*models.ClientConfig` and `Call` retries HTTP 429 responses with exponential backoff (1→10 min, max 5 retries).
- The 429 retry loop is copied verbatim from `admin/api_client_impl.go` — same context cancellation semantics, same backoff formula, same fall-through after max retries.
- Downstream consumers (e.g. the `exa-cq-cloudquery` CloudQuery plugin) can now opt into retry for Jira by passing a `ClientConfig`; passing `nil` preserves the defaults.

## Why

Previously a single 429 from Atlassian killed the request immediately — the Jira `Call` method was a bare `HTTP.Do` + `processResponse`. `admin` and `bitbucket` already had the retry pattern; Jira was the odd client out.

## What changed

**API clients** — signature change: `New(httpClient, site)` → `New(httpClient, site, config)`
- `jira/v2/api_client_impl.go`
- `jira/v3/api_client_impl.go`
- `jira/agile/api_client_impl.go`
- `jira/sm/api_client_impl.go`

Each file also gains `MaxRetries` / `InitialRetryDelay` / `MaxRetryDelay` fields on the `Client` struct, `log` + `time` imports, and the retry loop in `Call`. `NewRequest` and `processResponse` are untouched.

**Tests** — updated two patterns in each of the four `api_client_impl_test.go` files:
1. `TestNew` call sites pass `nil` for the new config arg (preserves default retry behavior).
2. `TestClient_Call` previously passed `request: nil`, which now panics because the new `Call` dereferences `request.Context()`. Each test now builds a real `*http.Request` via `http.NewRequestWithContext` and uses it in both the mock `Do` match and the test arg — same approach `admin`'s tests use.

**Docs** — `README.md` example updated to `v3.New(nil, host, nil)`.

## Breaking change

`New` gains a third required parameter in all four Jira packages. Callers must pass `nil` (or a `*models.ClientConfig`) as the third argument.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./jira/v2/... ./jira/v3/... ./jira/agile/... ./jira/sm/...` — all pass
- [x] `admin/` and `bitbucket/` untouched (confirmed via `git diff --name-only`)
- [x] Grep spot-check: every `v2.New(`, `v3.New(`, `agile.New(`, `sm.New(` call in the repo is now 3-arg

Note: the pre-existing failure in `jira/internal/user_search_impl_test.go` (`permissions=` vs `permission=`) reproduces on clean `main` and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)