### PR TITLE
Log Retry-After header on Jira 429 responses

### DIFF
--- a/jira/v2/api_client_impl.go
+++ b/jira/v2/api_client_impl.go
@@ -514,7 +514,8 @@ func (c *Client) Call(request *http.Request, structure interface{}) (*models.Res
 			if delay > c.MaxRetryDelay {
 				delay = c.MaxRetryDelay
 			}
-			log.Printf("Rate limit exceeded, sleeping for %v request %v", delay, request.URL.String())
+			retryAfter := response.Header.Get("Retry-After")
+			log.Printf("Rate limit exceeded (Retry-After=%q), sleeping for %v request %v", retryAfter, delay, request.URL.String())
 
 			// Get timer
 			timer := time.NewTimer(delay)


### PR DESCRIPTION
## Summary
- In `jira/v2` `Call()`, read the `Retry-After` response header on 429 and include it in the existing rate-limit log line so we have visibility into what Jira is asking us to wait.
- Behavior unchanged: sleep is still driven by `InitialRetryDelay`/`MaxRetryDelay` exponential backoff. Header value is logged only.