### PR TITLE
Log Jira rate limit headers on 429 for v3 client

### DIFF
--- a/jira/v3/api_client_impl.go
+++ b/jira/v3/api_client_impl.go
@@ -515,7 +515,14 @@ func (c *Client) Call(request *http.Request, structure interface{}) (*models.Res
 			if delay > c.MaxRetryDelay {
 				delay = c.MaxRetryDelay
 			}
-			log.Printf("Rate limit exceeded, sleeping for %v request %v", delay, request.URL.String())
+			h := response.Header
+			log.Printf("Rate limit exceeded (Retry-After=%q X-RateLimit-Limit=%q X-RateLimit-Remaining=%q X-RateLimit-Reset=%q RateLimit-Reason=%q), sleeping for %v request %v",
+				h.Get("Retry-After"),
+				h.Get("X-RateLimit-Limit"),
+				h.Get("X-RateLimit-Remaining"),
+				h.Get("X-RateLimit-Reset"),
+				h.Get("RateLimit-Reason"),
+				delay, request.URL.String())
 
 			// Get timer
 			timer := time.NewTimer(delay)


### PR DESCRIPTION
## Summary
- Mirror the header logging added in [#40](https://github.com/ExaForce/go-atlassian/pull/40) / [#41](https://github.com/ExaForce/go-atlassian/pull/41) (which only updated `jira/v2`) into `jira/v3/api_client_impl.go`.
- `jira/v3` is the client actually imported by the Atlassian source plugin in exa-cq-cloudquery, so users were still seeing the old `Rate limit exceeded, sleeping for %v request %v` line without `Retry-After`.
- Now logs `Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, and `RateLimit-Reason` on 429.