### PR TITLE
Honor Retry-After header for Jira v3 429 sleeps

### DIFF
--- a/jira/v3/api_client_impl.go
+++ b/jira/v3/api_client_impl.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -507,22 +508,31 @@ func (c *Client) Call(request *http.Request, structure interface{}) (*models.Res
 			return nil, err
 		}
 
-		// If rate limit exceeded, sleep with exponential backoff
+		// If rate limit exceeded, honor Retry-After or fall back to exponential backoff
 		if response.StatusCode == http.StatusTooManyRequests {
-			delay := c.InitialRetryDelay
-			// Use bit shifting for exponential backoff (1 << retryCount)
-			delay = delay * (1 << uint(retryCount))
-			if delay > c.MaxRetryDelay {
-				delay = c.MaxRetryDelay
-			}
 			h := response.Header
-			log.Printf("Rate limit exceeded (Retry-After=%q X-RateLimit-Limit=%q X-RateLimit-Remaining=%q X-RateLimit-Reset=%q RateLimit-Reason=%q), sleeping for %v request %v",
-				h.Get("Retry-After"),
+			retryAfterRaw := h.Get("Retry-After")
+
+			var delay time.Duration
+			var delaySource string
+			if secs, err := strconv.Atoi(retryAfterRaw); err == nil && secs > 0 {
+				delay = time.Duration(secs) * time.Second
+				delaySource = "Retry-After"
+			} else {
+				delay = c.InitialRetryDelay * (1 << uint(retryCount))
+				if delay > c.MaxRetryDelay {
+					delay = c.MaxRetryDelay
+				}
+				delaySource = "backoff"
+			}
+
+			log.Printf("Rate limit exceeded (Retry-After=%q X-RateLimit-Limit=%q X-RateLimit-Remaining=%q X-RateLimit-Reset=%q RateLimit-Reason=%q), sleeping for %v (source=%s) request %v",
+				retryAfterRaw,
 				h.Get("X-RateLimit-Limit"),
 				h.Get("X-RateLimit-Remaining"),
 				h.Get("X-RateLimit-Reset"),
 				h.Get("RateLimit-Reason"),
-				delay, request.URL.String())
+				delay, delaySource, request.URL.String())
 
 			// Get timer
 			timer := time.NewTimer(delay)


### PR DESCRIPTION
## Summary
- On HTTP 429 responses, the Jira v3 client now parses the `Retry-After` header (integer seconds) and sleeps for that duration instead of using only its computed exponential backoff.
- Falls back to the existing exponential backoff (capped at `MaxRetryDelay`) when the header is missing or unparseable, preserving today's behavior in those cases.
- Log line extended with `source=Retry-After|backoff` so operators can see which value drove each sleep.

## Why
Builds on #40 / #42 which started logging `Retry-After`. Now we actually honor it: retries happen sooner when the server permits, and we wait exactly as long as the server asks instead of guessing via exponential backoff.

## Scope
- `jira/v3/api_client_impl.go` only. The v2 client is unchanged by request.
- No new tests; the existing v3 test suite has no 429 fixtures.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./jira/v3/...`
- [ ] Manual verification against a Jira tenant returning 429 with a `Retry-After` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)